### PR TITLE
Set connect/read timeouts on connection

### DIFF
--- a/launchdarkly-server-sdk/src/data_source.rs
+++ b/launchdarkly-server-sdk/src/data_source.rs
@@ -89,6 +89,8 @@ impl StreamingDataSource {
                     .delay_max(Duration::from_secs(30))
                     .build(),
             )
+            .connect_timeout(Duration::from_secs(10))
+            .read_timeout(Duration::from_secs(300)) // LaunchDarkly sends keepalives every 3m
             .header("Authorization", sdk_key)?
             .header("User-Agent", &crate::USER_AGENT)?;
 


### PR DESCRIPTION
We have a suspicion that connections occasionally wedge in production. Setting connect/read timeouts should prevent the wedged connections from existing indefinitely.
