### PR TITLE
convert an error! to warn!

### DIFF
--- a/launchdarkly-server-sdk/src/data_source.rs
+++ b/launchdarkly-server-sdk/src/data_source.rs
@@ -173,7 +173,7 @@ impl DataSource for StreamingDataSource {
                                 }
                             },
                             Some(Err(e)) => {
-                                error!("error on event stream: {:?}; assuming event stream will reconnect", e);
+                                warn!("error on event stream: {:?}; assuming event stream will reconnect", e);
                                 continue;
                             },
                             None => {


### PR DESCRIPTION
As reported in [Slack](https://materializeinc.slack.com/archives/C050QABHSBZ/p1697006859977189), we're hitting this `error!` relatively often, and it's not a hard error, we should be able to recover from this. Because of that, we're downgrading this to a `warn!`
