### PR TITLE
bump lru to 0.12.0

### DIFF
--- a/launchdarkly-server-sdk/Cargo.toml
+++ b/launchdarkly-server-sdk/Cargo.toml
@@ -21,7 +21,7 @@ eventsource-client = { git = "https://github.com/MaterializeInc/rust-eventsource
 futures = "0.3.12"
 lazy_static = "1.4.0"
 log = "0.4.14"
-lru = { version = "0.11.0", default_features = false }
+lru = { version = "0.12.0", default_features = false }
 ring = "0.16.20"
 launchdarkly-server-sdk-evaluation = "1.0.0"
 serde = { version = "1.0.132", features = ["derive"] }


### PR DESCRIPTION
Bumps lru to 0.12.0 to avoid duplicate dependencies with few changes.
Needed for https://github.com/MaterializeInc/materialize/pull/23333